### PR TITLE
propager callid fra header til mdc

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEngine.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEngine.kt
@@ -10,6 +10,7 @@ import io.ktor.application.call
 import io.ktor.application.install
 import io.ktor.auth.authenticate
 import io.ktor.features.CORS
+import io.ktor.features.CallId
 import io.ktor.features.CallLogging
 import io.ktor.features.ContentNegotiation
 import io.ktor.features.StatusPages
@@ -76,10 +77,15 @@ fun createApplicationEngine(
             loginserviceIssuer = loginserviceIssuer,
             tokenXIssuer = tokenXIssuer
         )
-        install(CallLogging) {
-            mdc("Nav-Callid") { call ->
-                call.request.queryParameters["Nav-Callid"] ?: UUID.randomUUID().toString()
+        install(CallId) {
+            retrieve { it.request.queryParameters["Nav-Callid"] }
+            retrieveFromHeader("Nav-Callid")
+            generate {
+                UUID.randomUUID().toString()
             }
+        }
+        install(CallLogging) {
+            mdc("Nav-Callid") { it.callId }
             mdc("Nav-Consumer-Id") { call ->
                 call.request.queryParameters["Nav-Consumer-Id"] ?: "narmesteleder"
             }


### PR DESCRIPTION
Når [arbeidsgiver-notifikasjon-produsent-api](https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/pull/55) kaller api for nærmeste leder så ønsker vi å kunne spore disse basert på request header.
