### PR TITLE
Fjern inbound accessPolicy: notifikasjon-bruker-api

### DIFF
--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -73,8 +73,6 @@ spec:
         - application: sykmeldinger-arbeidsgiver
           namespace: teamsykmelding
           cluster: dev-gcp
-        - application: notifikasjon-bruker-api
-          namespace: fager
         - application: macgyver
           namespace: teamsykmelding
           cluster: dev-gcp

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -69,8 +69,6 @@ spec:
           namespace: team-esyfo
           cluster: prod-fss
         - application: sykmeldinger-arbeidsgiver
-        - application: notifikasjon-bruker-api
-          namespace: fager
         - application: macgyver
           namespace: teamsykmelding
           cluster: prod-gcp


### PR DESCRIPTION
notifikasjon-bruker-api trenger ikke lengere API-tilgang, da den lytter på kafka-topicet i stedet.